### PR TITLE
Add max-batch-size and max-transfer-size options

### DIFF
--- a/docs/accel-config-config-wq.md
+++ b/docs/accel-config-config-wq.md
@@ -56,6 +56,18 @@ request wq or "user" for regular character device driver use case to wq.
 configure the mode for the wq. The wq mode can be set as "dedicated" or
 "shared".
 
+`-c; --max-batch-size`
+specify the max batch size used by a work queue. The value should be
+between 1 and the device maximum batch size found in the
+max\_batch\_size attribute under device. If the value is not a power
+of 2, it will be rounded up to the next power of 2.
+
+`-x; --max-transfer-size`
+specify the max transfer size used by a work queue. The value should be
+between 1 and the device maximum transfer size found in the
+max\_transfer\_size attribute under device. If the value is not a power
+of 2, it will be rounded up to the next power of 2.
+
 COPYRIGHT
 =========
 


### PR DESCRIPTION
accel-config now supports wq max_batch_size and max_transfer_size attributes which can be configured using config-wq command. This change adds documentation of the 2 new options.